### PR TITLE
Solve CVE-2025-67735.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <!-- Not using the reactive, non-blocking (Reactor Netty) option at the moment.
+             The Tomcat/Jetty option is enabled through spring-boot-starter-web
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+        -->
         <dependency>
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>


### PR DESCRIPTION
Comment out the actually unused dependency spring-boot-starter-webflux,  
which is pulling in netty-transport-4.1.128.Final.jar
 (pkg:maven/io.netty/netty-transport) CVE-2025-67735(6.5).