### PR TITLE
Make admin user generation configurable

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -80,6 +80,7 @@ app.jwt.secret=abcccfghijklmnOOORSTUVWABC123456
 
 # if you want to have some default pass for the users automatically created on start (test@univ-unita.eu and it.support@univ-unita.eu)
 # If not, they will be a random generated one. They appear on the log on first startup
+ooapi.security.default.users.emails=test@univ-unita.eu,it.support@univ-unita.eu
 ooapi.security.default.users.pass=92k2k233c
 
 # Static HTMLs. (Tiny Dsahboard)


### PR DESCRIPTION
Use the ooapi.security.default.users.emails property to define email addresses to generate users for when they do not yet exist.  This is a comma separated list.

Closes #32.