### PR TITLE
Fix issue #40 (CVE-2025-68161)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
 
     <properties>
         <skipTests>true</skipTests>
+       <!-- Security override for SpringBoot-3.5.7,
+        CVE-2025-68161(6.3) with log4j-api-2.24.3 --> 
+       <log4j2.version>2.25.3</log4j2.version>        
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Users are advised to upgrade to Apache Log4j Core version 2.25.3
pom.xml is modified to use it