### PR TITLE
Fix #50 (Can not update freshly added course)

### DIFF
--- a/src/main/resources/static/js/forms.js
+++ b/src/main/resources/static/js/forms.js
@@ -892,6 +892,10 @@ $('#catalogForm').on('submit', async function (e) {
                     break;
 
             } // end switch
+            
+            // At this point the course is saved or updated, so we can go to preview course
+            window.location.href = "./course.html?courseId="+postCourseResponse.courseId;
+
 
         } // end if-else validate dates
 


### PR DESCRIPTION
Redirects to the course preview after creating or updating it, instead of remaining on form page.