### PR TITLE
Fix CVE-2026-29145 Based on tomcat-embed-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,11 @@
         <skipTests>true</skipTests>
        <!-- Security override for SpringBoot-3.5.7,
         CVE-2025-68161(6.3) with log4j-api-2.24.3 --> 
-       <log4j2.version>2.25.3</log4j2.version>        
+       <log4j2.version>2.25.3</log4j2.version>   
+       <!-- tomcat-embed-core tomcat 10.1.* raises CVE-2026-29145, CVE-2026-29129, 
+            CVE-2026-29146, CVE-2026-34483, CVE-2026-34487, CVE-2026-34500, 
+            CVE-2026-25854, CVE-2026-32990 -->   
+        <tomcat.version>11.0.21</tomcat.version>            
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fix https://github.com/open-education-api/oeapi-endpoint-quickstart/issues/75

Also implied CVE-2026-29129, CVE-2026-29146, CVE-2026-34483,
             CVE-2026-34487, CVE-2026-34500, CVE-2026-25854, 
             CVE-2026-32990

Validation checks warns:

`tomcat-embed-core-10.1.52.jar (pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.52, cpe:2.3:a:apache:tomcat:10.1.52:*:*:*:*:*:*:*, cpe:2.3:a:apache_tomcat:apache_tomcat:10.1.52:*:*:*:*:*:*:*) : CVE-2026-29145, CVE-2026-29129, CVE-2026-29146, CVE-2026-34483, CVE-2026-34487, CVE-2026-34500, CVE-2026-25854, CVE-2026-32990`

Update pom.xml adding    `<tomcat.version>11.0.21</tomcat.version>`