### PR TITLE
Fix #79 (https://github.com/open-education-api/oeapi-endpoint-quickst…

### DIFF
--- a/src/main/java/oeapi/payload/CourseDTO.java
+++ b/src/main/java/oeapi/payload/CourseDTO.java
@@ -52,6 +52,10 @@ public class CourseDTO extends oeapiEducationDTO {
 
     @JsonProperty("fieldsOfStudy")
     private String fieldsOfStudyId;
+    
+    @JsonProperty("duration")
+    private String duration;
+    
 
     @ValidEnumYaml(yamlfile = "sectorType.yml")
     private String sector;
@@ -173,6 +177,20 @@ public class CourseDTO extends oeapiEducationDTO {
      */
     public void setLevel(String level) {
         this.level = level;
+    }
+
+    /**
+     * @return the duration
+     */
+    public String getDuration() {
+        return duration;
+    }
+
+    /**
+     * @param duration the duration to set
+     */
+    public void setDuration(String duration) {
+        this.duration = duration;
     }
 
     /**


### PR DESCRIPTION
Fix https://github.com/open-education-api/oeapi-endpoint-quickstart/issues/79

Although the duration attribute was included when creating or updating a course via POST or PUT, it was not being saved together with the other Course attributes