### PR TITLE
Fix CVE-2026-40971

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
        <!-- tomcat-embed-core tomcat 10.1.* raises CVE-2026-29145, CVE-2026-29129, 
             CVE-2026-29146, CVE-2026-34483, CVE-2026-34487, CVE-2026-34500, 
             CVE-2026-25854, CVE-2026-32990 -->   
-        <tomcat.version>11.0.21</tomcat.version>            
+           <tomcat.version>11.0.22</tomcat.version>            
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.12</version>
+        <version>3.5.14</version>
         <relativePath/>
     </parent>
     <groupId>oeapi</groupId>


### PR DESCRIPTION
Fix https://github.com/open-education-api/oeapi-endpoint-quickstart/issues/81

Update spring-boot-starter-parent dependency to 3.5.14