### PR TITLE
Enable/Disable CVE Checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,14 +181,14 @@
                 </executions>                
             </plugin>
 
-            <plugin>
+<!--            <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
                 <version>12.1.9</version>
                 <configuration>
                     <nvdApiKeyEnvironmentVariable>NVD_API_TOKEN</nvdApiKeyEnvironmentVariable>
 
-                    <!-- need oss index user/password, we're fine without it for now -->
+                    --><!-- need oss index user/password, we're fine without it for now --><!--
                     <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
 
                     <suppressionFile>.dependency-check-suppressions.xml</suppressionFile>
@@ -200,7 +200,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin>-->
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The NVD database has become very slow and unstable over the last few months. Builds can take hours or even fail. Until the situation improves, the checks will be disabled. During this period, they will be run on demand instead of automatically. You can find the relevant configuration in the plugins section of the pom.xml.

To activate it, uncomment these lines

```
<!--            <plugin>
                <groupId>org.owasp</groupId>
                <artifactId>dependency-check-maven</artifactId>
                <version>12.1.9</version>
                <configuration>
                    <nvdApiKeyEnvironmentVariable>NVD_API_TOKEN</nvdApiKeyEnvironmentVariable>

                    --><!-- need oss index user/password, we're fine without it for now --><!--
                    <ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>

                    <suppressionFile>.dependency-check-suppressions.xml</suppressionFile>
                </configuration>
                <executions>
                    <execution>
                        <goals>
                            <goal>check</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
-->
```
Related with https://github.com/open-education-api/oeapi-endpoint-quickstart/issues/107
