### PR TITLE
Organization.primaryCode.codeType is a "extensible enumeration"

### DIFF
--- a/src/main/resources/schemas/organization.yml
+++ b/src/main/resources/schemas/organization.yml
@@ -5,7 +5,6 @@ properties:
     properties:
       codeType:
         type: string
-        enum: ["identifier", "otherType"] # Enumerated values
       code:
         type: string
     required: ["codeType", "code"]


### PR DESCRIPTION
See also: https://github.com/open-education-api/specification/blob/release/5.0/v5/enumerations/codeType.yaml

Fixes: #104 