### PR TITLE
Add push to surf container registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,18 @@ jobs:
       packages: write # Required to publish to GHCR
 
     steps:
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v4.1.2
+
     - name: Checkout code
       uses: actions/checkout@v6
+
+    - name: Log in to SURF CR
+      uses: docker/login-action@v3
+      with:
+        registry: cr.surf.nl
+        username: ${{ secrets.HARBOR_USERNAME }}
+        password: ${{ secrets.HARBOR_PASSWORD }}
 
     - name: Log in to GHCR
       uses: docker/login-action@v3
@@ -36,7 +46,9 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ghcr.io/${{ github.repository }}
+        images: |
+          ghcr.io/${{ github.repository }}
+          cr.surf.nl/oeapi-endpoint-quickstart/oeapi-endpoint-quickstart
         tags: |
           type=schedule
           type=ref,event=branch
@@ -51,3 +63,15 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+    - name: Sign image with a key
+      run: |
+        images=""
+        for tag in ${TAGS}; do
+          cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${tag}@${DIGEST} --new-bundle-format=false --use-signing-config=false
+        done
+      env:
+        TAGS: ${{ steps.meta.outputs.tags }}
+        COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+        COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        DIGEST: ${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
Adds a push to the SURF container registry. This registry requires images to be signed so also added cosign to the job.

All secrets that are referred to have been added to the repository.