### PR TITLE
User CRUD endpoints for admins

### DIFF
--- a/src/main/java/oeapi/controller/admin/RoleController.java
+++ b/src/main/java/oeapi/controller/admin/RoleController.java
@@ -1,0 +1,27 @@
+package oeapi.controller.admin;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import oeapi.controller.requestparameters.oeapiRequestParam;
+import oeapi.model.Role;
+import oeapi.repository.RoleRepository;
+
+@RestController
+@RequestMapping("/admin/roles")
+public class RoleController {
+    @Autowired
+    RoleRepository roleRepository;
+
+    @GetMapping(produces = "application/json")
+    public ResponseEntity<?> getAll(@ModelAttribute oeapiRequestParam requestParam) {
+        List<Role> roles = roleRepository.findAll();
+        return ResponseEntity.ok(roles);
+    }
+}

--- a/src/main/java/oeapi/controller/admin/UserController.java
+++ b/src/main/java/oeapi/controller/admin/UserController.java
@@ -1,0 +1,101 @@
+package oeapi.controller.admin;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import oeapi.controller.requestparameters.oeapiRequestParam;
+import oeapi.model.User;
+import oeapi.repository.UserRepository;
+
+@RestController
+@RequestMapping("/admin/users")
+public class UserController {
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @GetMapping(produces = "application/json")
+    public ResponseEntity<?> getAll(@ModelAttribute oeapiRequestParam requestParam) {
+        List<User> users = userRepository.findAll().stream().map(user -> cleanupUser(user)).toList();
+        return ResponseEntity.ok(users);
+    }
+
+    @GetMapping(value = "/{id}", produces = "application/json")
+    public ResponseEntity<?> get(@PathVariable Integer id) {
+        Optional<User> maybeUser = userRepository.findById(id);
+        if (maybeUser.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        User user = cleanupUser(maybeUser.get());
+        return ResponseEntity.ok(user);
+    }
+
+    @PostMapping(produces = "application/json")
+    public ResponseEntity<?> create(@Valid @RequestBody User user) {
+        if (userRepository.existsUserByEmail(user.getEmail())) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        userRepository.save(user);
+
+        return ResponseEntity.ok(cleanupUser(user));
+    }
+
+    @PutMapping(value = "/{id}", produces = "application/json")
+    public ResponseEntity<?> put(@PathVariable Integer id, @Valid @RequestBody User user) {
+        Optional<User> maybeUser = userRepository.findById(id);
+        if (maybeUser.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        User original = maybeUser.get();
+        original.setEmail(user.getEmail());
+        if (user.getPassword() != null) {
+            original.setPassword(passwordEncoder.encode(user.getPassword()));
+        }
+        original.setRoles(user.getRoles());
+        userRepository.save(original);
+
+        return ResponseEntity.ok(cleanupUser(original));
+    }
+
+    @DeleteMapping(value = "/{id}", produces = "application/json")
+    public ResponseEntity<?> delete(@PathVariable Integer id) {
+        Optional<User> maybeUser = userRepository.findById(id);
+        if (maybeUser.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        User user = maybeUser.get();
+        userRepository.delete(user);
+
+        return ResponseEntity.ok(cleanupUser(user));
+    }
+
+
+
+    private User cleanupUser(User user) {
+        User clean = new User();
+        clean.setId(user.getId());
+        clean.setEmail(user.getEmail());
+        clean.setRoles(user.getRoles());
+        return clean;
+    }
+}

--- a/src/main/java/oeapi/model/Role.java
+++ b/src/main/java/oeapi/model/Role.java
@@ -24,7 +24,10 @@ public class Role {
     private String name;
 
     public Role() {
+    }
 
+    public Role(Integer id) {
+        this.id = id;
     }
 
     public Role(String name) {

--- a/src/main/java/oeapi/security/ApplicationSecurity.java
+++ b/src/main/java/oeapi/security/ApplicationSecurity.java
@@ -61,6 +61,9 @@ public class ApplicationSecurity {
             auth.requestMatchers(HttpMethod.GET, "/js/*").permitAll();
             auth.requestMatchers(HttpMethod.GET, "/_quickdashboard_config.json").permitAll();
 
+            // All /admin/ endpoints need an admin user!
+            auth.requestMatchers("/admin/*").hasRole("ADMIN");
+
             // 2. Mode‑specific logic
             switch (endpointSecMode.toLowerCase()) {
 

--- a/src/test/java/oeapi/controller/admin/RoleControllerTest.java
+++ b/src/test/java/oeapi/controller/admin/RoleControllerTest.java
@@ -1,0 +1,55 @@
+package oeapi.controller.admin;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import oeapi.model.Role;
+import oeapi.repository.RoleRepository;
+import oeapi.repository.UserRepository;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class RoleControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    RoleRepository roleRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        userRepository.deleteAll(); // delete automatically created users
+        roleRepository.deleteAll();
+        roleRepository.save(new Role("first"));
+        roleRepository.save(new Role("second"));
+    }
+
+    @Test
+    void testGetAll() throws Exception {
+        mockMvc.perform(get("/admin/roles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].id").exists())
+                .andExpect(jsonPath("$[0].name").exists())
+                .andExpect(jsonPath("$[1].id").exists())
+                .andExpect(jsonPath("$[1].name").exists());
+    }
+}

--- a/src/test/java/oeapi/controller/admin/UserControllerTest.java
+++ b/src/test/java/oeapi/controller/admin/UserControllerTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -21,6 +22,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +35,7 @@ import oeapi.repository.UserRepository;
 @Transactional
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"ooapi.security.enabled=true", "ooapi.security.mode=restricted"})
 class UserControllerTest {
     @Autowired
     MockMvc mockMvc;
@@ -63,28 +67,30 @@ class UserControllerTest {
         user = userRepository.save(user);
     }
 
-    @Test
-    void testGetAll() throws Exception {
-        mockMvc.perform(get("/admin/users"))
+    @Nested
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    class WithAdminUser {
+        void testGetAll() throws Exception {
+            mockMvc.perform(get("/admin/users"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$[0].email").value(user.getEmail()))
                 .andExpect(jsonPath("$[0].password").doesNotExist());
-    }
+        }
 
-    @Test
-    void testGetAllWithoutUsers() throws Exception {
-        userRepository.deleteAll();
+        @Test
+        void testGetAllWithoutUsers() throws Exception {
+            userRepository.deleteAll();
 
-        mockMvc.perform(get("/admin/users"))
+            mockMvc.perform(get("/admin/users"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$", hasSize(0)));
-    }
+        }
 
-    @Test
-    void testGetById() throws Exception {
-        mockMvc.perform(get("/admin/users/{id}", user.getId()))
+        @Test
+        void testGetById() throws Exception {
+            mockMvc.perform(get("/admin/users/{id}", user.getId()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").value(user.getId()))
@@ -92,16 +98,16 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.roles[0].name").value(user.getRoles().get(0).getName()))
                 .andExpect(jsonPath("$.email").value(user.getEmail()))
                 .andExpect(jsonPath("$.password").doesNotExist());
-    }
+        }
 
-    @Test
-    void testPost() throws Exception {
-        User newUser = new User("wilma@example.com", "fred");
-        newUser.setRoles(Arrays.asList(role));
+        @Test
+        void testPost() throws Exception {
+            User newUser = new User("wilma@example.com", "fred");
+            newUser.setRoles(Arrays.asList(role));
 
-        String json = mockMvc
+            String json = mockMvc
                 .perform(post("/admin/users").contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(newUser)))
+                         .content(new ObjectMapper().writeValueAsString(newUser)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").exists())
@@ -109,33 +115,33 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.password").doesNotExist())
                 .andReturn().getResponse().getContentAsString();
 
-        JsonNode node = mapper.readTree(json);
-        int id = node.at("/id").asInt();
-        Optional<User> maybeUser = userRepository.findById(id);
-        assertTrue(maybeUser.isPresent(), "user saved");
+            JsonNode node = mapper.readTree(json);
+            int id = node.at("/id").asInt();
+            Optional<User> maybeUser = userRepository.findById(id);
+            assertTrue(maybeUser.isPresent(), "user saved");
 
-        User createdUser = maybeUser.get();
-        assertTrue(passwordEncoder.matches(newUser.getPassword(), createdUser.getPassword()), "password properly encoded");
+            User createdUser = maybeUser.get();
+            assertTrue(passwordEncoder.matches(newUser.getPassword(), createdUser.getPassword()), "password properly encoded");
 
-        List<Role> roles = createdUser.getRoles();
-        assertTrue(roles.size() == 1, "roles added");
-    }
+            List<Role> roles = createdUser.getRoles();
+            assertTrue(roles.size() == 1, "roles added");
+        }
 
-    @Test
-    void testPostExisting() throws Exception {
-        mockMvc.perform(post("/admin/users").contentType(MediaType.APPLICATION_JSON).content(new ObjectMapper().writeValueAsString(user)))
-            .andExpect(status().isBadRequest());
-    }
+        @Test
+        void testPostExisting() throws Exception {
+            mockMvc.perform(post("/admin/users").contentType(MediaType.APPLICATION_JSON).content(new ObjectMapper().writeValueAsString(user)))
+                .andExpect(status().isBadRequest());
+        }
 
-    @Test
-    void testPut() throws Exception {
-        User updateUser = new User("barney@example.com", null);
-        updateUser.setRoles(Arrays.asList(role, otherRole));
+        @Test
+        void testPut() throws Exception {
+            User updateUser = new User("barney@example.com", null);
+            updateUser.setRoles(Arrays.asList(role, otherRole));
 
-        String json = mockMvc
+            String json = mockMvc
                 .perform(put("/admin/users/{id}", user.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(updateUser)))
+                         .contentType(MediaType.APPLICATION_JSON)
+                         .content(new ObjectMapper().writeValueAsString(updateUser)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").exists())
@@ -143,25 +149,25 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.password").doesNotExist())
                 .andReturn().getResponse().getContentAsString();
 
-        JsonNode node = mapper.readTree(json);
-        int id = node.at("/id").asInt();
-        assertTrue(id == user.getId(), "updated correct user");
+            JsonNode node = mapper.readTree(json);
+            int id = node.at("/id").asInt();
+            assertTrue(id == user.getId(), "updated correct user");
 
-        User updatedUser = userRepository.findById(id).get();
+            User updatedUser = userRepository.findById(id).get();
 
-        List<Role> roles = updatedUser.getRoles();
-        assertTrue(roles.size() == 2, "roles added");
-    }
+            List<Role> roles = updatedUser.getRoles();
+            assertTrue(roles.size() == 2, "roles added");
+        }
 
-    @Test
-    void testPutWithRoleIdsOnly() throws Exception {
-        User updateUser = new User("barney@example.com", null);
-        updateUser.setRoles(Arrays.asList(new Role(otherRole.getId())));
+        @Test
+        void testPutWithRoleIdsOnly() throws Exception {
+            User updateUser = new User("barney@example.com", null);
+            updateUser.setRoles(Arrays.asList(new Role(otherRole.getId())));
 
-        String json = mockMvc
+            String json = mockMvc
                 .perform(put("/admin/users/{id}", user.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(updateUser)))
+                         .contentType(MediaType.APPLICATION_JSON)
+                         .content(new ObjectMapper().writeValueAsString(updateUser)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").exists())
@@ -169,26 +175,36 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.password").doesNotExist())
                 .andReturn().getResponse().getContentAsString();
 
-        JsonNode node = mapper.readTree(json);
-        int id = node.at("/id").asInt();
-        assertTrue(id == user.getId(), "updated correct user");
+            JsonNode node = mapper.readTree(json);
+            int id = node.at("/id").asInt();
+            assertTrue(id == user.getId(), "updated correct user");
 
-        User updatedUser = userRepository.findById(id).get();
+            User updatedUser = userRepository.findById(id).get();
 
-        List<Role> roles = updatedUser.getRoles();
-        assertTrue(roles.size() == 1, "roles changed");
-        assertEquals(otherRole, roles.get(0), "correct role");
-    }
+            List<Role> roles = updatedUser.getRoles();
+            assertTrue(roles.size() == 1, "roles changed");
+            assertEquals(otherRole, roles.get(0), "correct role");
+        }
 
-    @Test
-    void testDelete() throws Exception {
-        Optional<User> maybeUser = userRepository.findById(user.getId());
-        assertTrue(maybeUser.isPresent(), "user exists");
+        @Test
+        void testDelete() throws Exception {
+            Optional<User> maybeUser = userRepository.findById(user.getId());
+            assertTrue(maybeUser.isPresent(), "user exists");
 
-        mockMvc.perform(delete("/admin/users/{id}", user.getId()))
+            mockMvc.perform(delete("/admin/users/{id}", user.getId()))
                 .andExpect(status().isOk());
 
-        maybeUser = userRepository.findById(user.getId());
-        assertTrue(maybeUser.isEmpty(), "user deleted");
+            maybeUser = userRepository.findById(user.getId());
+            assertTrue(maybeUser.isEmpty(), "user deleted");
+        }
+    }
+
+    @Nested
+    class WithoutAdminUser {
+        @Test
+        void testGetAll() throws Exception {
+            mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isForbidden());
+        }
     }
 }

--- a/src/test/java/oeapi/controller/admin/UserControllerTest.java
+++ b/src/test/java/oeapi/controller/admin/UserControllerTest.java
@@ -1,0 +1,194 @@
+package oeapi.controller.admin;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import oeapi.model.Role;
+import oeapi.model.User;
+import oeapi.repository.RoleRepository;
+import oeapi.repository.UserRepository;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class UserControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    RoleRepository roleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    private User user;
+    private Role role;
+    private Role otherRole;
+
+    @BeforeEach
+    void beforeEach() {
+        roleRepository.deleteAll();
+        role = roleRepository.save(new Role("test"));
+        otherRole = roleRepository.save(new Role("yelp"));
+
+        userRepository.deleteAll();
+        user = new User("fred@example.com", "wilma");
+        user.setRoles(Arrays.asList(role));
+        user = userRepository.save(user);
+    }
+
+    @Test
+    void testGetAll() throws Exception {
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].email").value(user.getEmail()))
+                .andExpect(jsonPath("$[0].password").doesNotExist());
+    }
+
+    @Test
+    void testGetAllWithoutUsers() throws Exception {
+        userRepository.deleteAll();
+
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void testGetById() throws Exception {
+        mockMvc.perform(get("/admin/users/{id}", user.getId()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(user.getId()))
+                .andExpect(jsonPath("$.roles", hasSize(user.getRoles().size())))
+                .andExpect(jsonPath("$.roles[0].name").value(user.getRoles().get(0).getName()))
+                .andExpect(jsonPath("$.email").value(user.getEmail()))
+                .andExpect(jsonPath("$.password").doesNotExist());
+    }
+
+    @Test
+    void testPost() throws Exception {
+        User newUser = new User("wilma@example.com", "fred");
+        newUser.setRoles(Arrays.asList(role));
+
+        String json = mockMvc
+                .perform(post("/admin/users").contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(newUser)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.email").value(newUser.getEmail()))
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode node = mapper.readTree(json);
+        int id = node.at("/id").asInt();
+        Optional<User> maybeUser = userRepository.findById(id);
+        assertTrue(maybeUser.isPresent(), "user saved");
+
+        User createdUser = maybeUser.get();
+        assertTrue(passwordEncoder.matches(newUser.getPassword(), createdUser.getPassword()), "password properly encoded");
+
+        List<Role> roles = createdUser.getRoles();
+        assertTrue(roles.size() == 1, "roles added");
+    }
+
+    @Test
+    void testPostExisting() throws Exception {
+        mockMvc.perform(post("/admin/users").contentType(MediaType.APPLICATION_JSON).content(new ObjectMapper().writeValueAsString(user)))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testPut() throws Exception {
+        User updateUser = new User("barney@example.com", null);
+        updateUser.setRoles(Arrays.asList(role, otherRole));
+
+        String json = mockMvc
+                .perform(put("/admin/users/{id}", user.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(updateUser)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.email").value(updateUser.getEmail()))
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode node = mapper.readTree(json);
+        int id = node.at("/id").asInt();
+        assertTrue(id == user.getId(), "updated correct user");
+
+        User updatedUser = userRepository.findById(id).get();
+
+        List<Role> roles = updatedUser.getRoles();
+        assertTrue(roles.size() == 2, "roles added");
+    }
+
+    @Test
+    void testPutWithRoleIdsOnly() throws Exception {
+        User updateUser = new User("barney@example.com", null);
+        updateUser.setRoles(Arrays.asList(new Role(otherRole.getId())));
+
+        String json = mockMvc
+                .perform(put("/admin/users/{id}", user.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(updateUser)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.email").value(updateUser.getEmail()))
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode node = mapper.readTree(json);
+        int id = node.at("/id").asInt();
+        assertTrue(id == user.getId(), "updated correct user");
+
+        User updatedUser = userRepository.findById(id).get();
+
+        List<Role> roles = updatedUser.getRoles();
+        assertTrue(roles.size() == 1, "roles changed");
+        assertEquals(otherRole, roles.get(0), "correct role");
+    }
+
+    @Test
+    void testDelete() throws Exception {
+        Optional<User> maybeUser = userRepository.findById(user.getId());
+        assertTrue(maybeUser.isPresent(), "user exists");
+
+        mockMvc.perform(delete("/admin/users/{id}", user.getId()))
+                .andExpect(status().isOk());
+
+        maybeUser = userRepository.findById(user.getId());
+        assertTrue(maybeUser.isEmpty(), "user deleted");
+    }
+}


### PR DESCRIPTION
Endpoints implemented:

- GET /admin/roles
- GET /admin/users
- POST /admin/users
- PUT /admin/users/{id}
- DELETE /admin/users/{id}

Note: set user roles as follows:

```
PUT /admin/users/1

{"email": "user@example.com",
 "roles": [{"id": 1}, {"id": 2}]}
```

Same thing for POST.